### PR TITLE
Added deployment to PluginPlaceholders

### DIFF
--- a/v1/api.go
+++ b/v1/api.go
@@ -145,4 +145,9 @@ type PluginPlaceholders struct {
 
 	// protocol buffer package name, e.g. namespace.v1_testservice.v1
 	ProtoPackage string
+
+	// ----------------------- graphql --------------------------
+
+	// deployment type, e.g. standalone-graphql, standalone-gateway
+	Deployment string
 }


### PR DESCRIPTION
Passing deployment type down to plugins for use in graphql